### PR TITLE
fix: prevent duplicate ingredient manager dialogs

### DIFF
--- a/main.js
+++ b/main.js
@@ -221,13 +221,6 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
 
-  // Lazy import manager dialog when clicked
-  document.getElementById('miManageIngredients')?.addEventListener('click', async () => {
-    closeOverflow();
-    const mod = await import('./features/items.js');
-    mod.openItemsManagerDialog?.();
-  });
-
   // Features
   initListFeature();
   initRecipesFeature();


### PR DESCRIPTION
## Summary
- remove duplicate click handler for Ingrediënten beheren overflow action to stop double dialogs

## Testing
- `node --check main.js`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae035334a4832688678ee3c5ea005f