### PR TITLE
Remove duplicate ingredients handler

### DIFF
--- a/main.js
+++ b/main.js
@@ -220,14 +220,6 @@ document.addEventListener('DOMContentLoaded', () => {
     location.hash = '#/stores';
   });
 
-
-  // Lazy import manager dialog when clicked
-  document.getElementById('miManageIngredients')?.addEventListener('click', async () => {
-    closeOverflow();
-    const mod = await import('./features/items.js');
-    mod.openItemsManagerDialog?.();
-  });
-
   // Features
   initListFeature();
   initRecipesFeature();


### PR DESCRIPTION
## Summary
- Remove duplicate `miManageIngredients` click handler so the ingredients dialog opens only once.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node - <<'NODE' ...` dialog opened 1 time(s)


------
https://chatgpt.com/codex/tasks/task_e_68ae04bae370832682c24e3bafa4f6a2