### PR TITLE
Add tests for parseItems helper

### DIFF
--- a/features/__tests__/recipes.parseItems.test.js
+++ b/features/__tests__/recipes.parseItems.test.js
@@ -1,0 +1,20 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+test('trims whitespace and removes blank entries', async () => {
+  const { parseItems } = await import('../recipes.js');
+  const raw = '  apple  \n  \n banana   \n';
+  assert.deepStrictEqual(parseItems(raw), ['apple', 'banana']);
+});
+
+test('splits by commas or newlines', async () => {
+  const { parseItems } = await import('../recipes.js');
+  const raw = 'apple,banana\ncarrot';
+  assert.deepStrictEqual(parseItems(raw), ['apple', 'banana', 'carrot']);
+});
+
+test('deduplicates repeated ingredients', async () => {
+  const { parseItems } = await import('../recipes.js');
+  const raw = 'apple, banana\napple, banana';
+  assert.deepStrictEqual(parseItems(raw), ['apple', 'banana']);
+});

--- a/features/recipes.js
+++ b/features/recipes.js
@@ -204,7 +204,7 @@ async function onDialogDelete(){
 }
 
 /* ---------- Shared helpers ---------- */
-function parseItems(raw){
+export function parseItems(raw){
   return Array.from(new Set(
     (raw || "")
       .split(/[\n,]+/)


### PR DESCRIPTION
## Summary
- Export parseItems from recipes feature
- Add tests covering whitespace trimming, splitting, and deduplication

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68ae04d761f08326967f3c02bf40defc