### PR TITLE
Add progress ring to show list completion

### DIFF
--- a/features/list.js
+++ b/features/list.js
@@ -200,6 +200,8 @@ function updateProgressRing(){
   circle.style.strokeDasharray = `${circumference}`;
   const offset = circumference - (total ? (checked / total) : 0) * circumference;
   circle.style.strokeDashoffset = offset;
+  const complete = total > 0 && checked === total;
+  svg.classList.toggle('completed', complete);
 }
 function setActiveFromCloud(cloudDocs){
   activeItems = {};

--- a/features/list.js
+++ b/features/list.js
@@ -187,6 +187,20 @@ function updateCounter(){
   const n = activeMeals.size;
   el.textContent = n === 1 ? "1 dag" : `${n} dagen`;
 }
+
+function updateProgressRing(){
+  const svg = document.getElementById('progressRing');
+  if (!svg) return;
+  const circle = svg.querySelector('.ring-progress');
+  if (!circle) return;
+  const total = Object.keys(activeItems).length;
+  const checked = Object.values(activeItems).filter(i => i.checked).length;
+  const radius = circle.r.baseVal.value;
+  const circumference = 2 * Math.PI * radius;
+  circle.style.strokeDasharray = `${circumference}`;
+  const offset = circumference - (total ? (checked / total) : 0) * circumference;
+  circle.style.strokeDashoffset = offset;
+}
 function setActiveFromCloud(cloudDocs){
   activeItems = {};
   cloudDocs.forEach(d => {
@@ -200,6 +214,7 @@ function setActiveFromCloud(cloudDocs){
   refreshKnownItems();
   renderList();
   setClearCtaVisible(cloudDocs.length > 0);
+  updateProgressRing();
 }
 
 // MVP STEP-1: toggle visibility of bottom clear CTA
@@ -282,6 +297,8 @@ function renderList(){
       // Checkbox toggle
       const cb = row.querySelector('input[type="checkbox"]');
       cb.addEventListener("change", async () => {
+        activeItems[name].checked = cb.checked;
+        updateProgressRing();
         await cloudToggleCheck(name, cb.checked);
       });
 
@@ -313,6 +330,8 @@ function renderList(){
 
     ul.appendChild(li);
   });
+
+  updateProgressRing();
 }
 
 

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
           <svg id="progressRing" viewBox="0 0 36 36">
             <circle class="ring-bg" cx="18" cy="18" r="16"></circle>
             <circle class="ring-progress" cx="18" cy="18" r="16"></circle>
+            <text class="ring-check" x="18" y="21">✓</text>
           </svg>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -19,7 +19,13 @@
 </head>
 <body>
     <div class="app">
-        <h1>Weekboodschappen</h1>
+        <div class="app-header">
+          <h1>Weekboodschappen</h1>
+          <svg id="progressRing" viewBox="0 0 36 36">
+            <circle class="ring-bg" cx="18" cy="18" r="16"></circle>
+            <circle class="ring-progress" cx="18" cy="18" r="16"></circle>
+          </svg>
+        </div>
 
         <!-- TAB: LIST (current UI) -->
         <section id="tab-list" class="tabpage active">

--- a/styles.css
+++ b/styles.css
@@ -88,6 +88,27 @@ h1 {
   stroke-dashoffset:100;
   transition:stroke-dashoffset .3s ease;
 }
+#progressRing .ring-check{
+  font-size:.9rem;
+  text-anchor:middle;
+  fill:var(--accent);
+  opacity:0;
+  transition:opacity .3s ease;
+}
+#progressRing.completed .ring-progress{
+  stroke:var(--accent);
+}
+#progressRing.completed .ring-check{
+  opacity:1;
+}
+#progressRing.completed{
+  animation:ring-pop .6s ease;
+}
+@keyframes ring-pop{
+  0%{transform:rotate(-90deg) scale(1);}
+  50%{transform:rotate(-90deg) scale(1.1);}
+  100%{transform:rotate(-90deg) scale(1);}
+}
 
 .section-label {
   font-size: 1rem;

--- a/styles.css
+++ b/styles.css
@@ -71,12 +71,13 @@ h1 {
 #progressRing{
   width:2.5rem;
   height:2.5rem;
-  transform:rotate(-90deg);
   flex-shrink:0;
 }
 #progressRing circle{
   fill:none;
   stroke-width:4;
+  transform:rotate(-90deg);
+  transform-origin:50% 50%;
 }
 #progressRing .ring-bg{
   stroke:var(--border);
@@ -105,9 +106,9 @@ h1 {
   animation:ring-pop .6s ease;
 }
 @keyframes ring-pop{
-  0%{transform:rotate(-90deg) scale(1);}
-  50%{transform:rotate(-90deg) scale(1.1);}
-  100%{transform:rotate(-90deg) scale(1);}
+  0%{transform:scale(1);}
+  50%{transform:scale(1.1);}
+  100%{transform:scale(1);}
 }
 
 .section-label {

--- a/styles.css
+++ b/styles.css
@@ -61,6 +61,34 @@ h1 {
   color: var(--primary);
 }
 
+.app-header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+}
+
+#progressRing{
+  width:2.5rem;
+  height:2.5rem;
+  transform:rotate(-90deg);
+  flex-shrink:0;
+}
+#progressRing circle{
+  fill:none;
+  stroke-width:4;
+}
+#progressRing .ring-bg{
+  stroke:var(--border);
+}
+#progressRing .ring-progress{
+  stroke:var(--primary);
+  stroke-linecap:round;
+  stroke-dasharray:100;
+  stroke-dashoffset:100;
+  transition:stroke-dashoffset .3s ease;
+}
+
 .section-label {
   font-size: 1rem;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- Add SVG progress ring next to list header to visualize checked items
- Compute and update progress ring based on `activeItems` selections
- Style progress ring and header for mobile-friendly radial animation

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68ae079693ac83268b7203b92d0a3359