### PR TITLE
Hide completed items by default

### DIFF
--- a/features/list.js
+++ b/features/list.js
@@ -7,6 +7,7 @@ let activeItems = {};                   // { name: { count, sources:Set, checked
 let customRecipeDocs = {};              // name -> { id, items: string[] }
 let combinedMeals = {};                 // name -> items[] (strings)
 let KNOWN_ITEMS = [];
+let showCompleted = false;
 
 /** Recents (STEP-3) */
 const RECENTS_KEY = "grocify_recents_v1";
@@ -98,7 +99,9 @@ export function initListFeature(){
   wireDetailsSections();
   wireAddDialog();
   wireClearList();
+  wireToggleCompleted();
   setClearCtaVisible(false);
+  setToggleCompletedVisible(false);
 
   // Refresh suggestions on composer open (STEP-3)
   document.addEventListener('composer:open', () => {
@@ -216,7 +219,6 @@ function setActiveFromCloud(cloudDocs){
   refreshKnownItems();
   renderList();
   setClearCtaVisible(cloudDocs.length > 0);
-  updateProgressRing();
 }
 
 // MVP STEP-1: toggle visibility of bottom clear CTA
@@ -226,12 +228,25 @@ function setClearCtaVisible(hasItems){
   btn.style.display = hasItems ? 'block' : 'none';
 }
 
+function setToggleCompletedVisible(hasChecked){
+  const btn = document.getElementById('toggleCompletedBtn');
+  if (!btn) return;
+  btn.style.display = hasChecked ? 'block' : 'none';
+}
+
 function renderList(){
   const ul = document.getElementById("shoppingList");
   if (!ul) return;
 
   // Clear current DOM
   ul.innerHTML = "";
+
+  const hasChecked = Object.values(activeItems).some(i => i.checked);
+  const toggleBtn = document.getElementById('toggleCompletedBtn');
+  if (toggleBtn) {
+    toggleBtn.textContent = showCompleted ? 'Afgevinkte items verbergen' : 'Afgevinkte items tonen';
+  }
+  setToggleCompletedVisible(hasChecked);
 
   // One global click handler to close any open overflow menus
   if (window.__grocifyCloseMenus) {
@@ -252,7 +267,9 @@ function renderList(){
     const items = Object.keys(activeItems)
       .filter(name => (ITEM_TO_SECTION[name] || inferSection(name)) === section);
 
-    if (items.length === 0) return;
+    const uncheckedCount = items.filter(n => !activeItems[n].checked).length;
+    const visibleItems = showCompleted ? items : items.filter(n => !activeItems[n].checked);
+    if (visibleItems.length === 0) return;
 
     const li = document.createElement("li");
     li.className = "section";
@@ -260,14 +277,14 @@ function renderList(){
       <div class="section__header">
         <h3>${section}</h3>
         <span class="section__count">
-          ${items.filter(n => !activeItems[n].checked).length}/${items.length}
+          ${uncheckedCount}/${items.length}
         </span>
       </div>
       <ul class="section__items"></ul>
     `;
     const inner = li.querySelector(".section__items");
 
-    items.sort((a,b) => a.localeCompare(b)).forEach(name => {
+    visibleItems.sort((a,b) => a.localeCompare(b)).forEach(name => {
       const data = activeItems[name];
       const row = document.createElement("li");
       row.className = "item-row";
@@ -300,7 +317,7 @@ function renderList(){
       const cb = row.querySelector('input[type="checkbox"]');
       cb.addEventListener("change", async () => {
         activeItems[name].checked = cb.checked;
-        updateProgressRing();
+        renderList();
         await cloudToggleCheck(name, cb.checked);
       });
 
@@ -632,6 +649,16 @@ function wireClearList(){
     }
     });
 
+}
+
+function wireToggleCompleted(){
+  const btn = document.getElementById('toggleCompletedBtn');
+  if(!btn) return;
+  btn.addEventListener('click', () => {
+    showCompleted = !showCompleted;
+    renderList();
+  });
+  btn.textContent = showCompleted ? 'Afgevinkte items verbergen' : 'Afgevinkte items tonen';
 }
 
 /* --- Unified floating tray (icon-only) --- */

--- a/index.html
+++ b/index.html
@@ -33,6 +33,8 @@
             <!-- ⬇️ KEEP your existing List UI inside this section ⬇️ -->
             <ul class="shopping-list" id="shoppingList"></ul>
 
+            <button id="toggleCompletedBtn" class="clear-list" style="display:none;">Afgevinkte items tonen</button>
+
             <!-- Your existing FAB & Clear button stay here (only relevant on List tab) -->
             <button id="fabAdd" class="fab" title="Item toevoegen">＋</button>
             <!-- Bottom-sheet composer (new) -->


### PR DESCRIPTION
## Summary
- hide checked shopping items unless user chooses to show them
- add button to toggle visibility of completed items

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0c56dca88326860ee84224b931f8