### PR TITLE
Animate FAB into close icon

### DIFF
--- a/main.js
+++ b/main.js
@@ -87,7 +87,13 @@ const Composer = (() => {
 document.addEventListener('DOMContentLoaded', () => {
   Composer.wire();
   const fab = document.getElementById('fabAdd');
-  fab?.addEventListener('click', () => Composer.open());
+  fab?.addEventListener('click', () => {
+    if (document.body.classList.contains('modal-open')) {
+      Composer.close();
+    } else {
+      Composer.open();
+    }
+  });
   document.addEventListener('composer:request-close', () => Composer.close());
 });
 

--- a/styles.css
+++ b/styles.css
@@ -439,9 +439,20 @@ dialog{
   border: none; background: var(--primary); color: #fff;
   font-size: 28px; line-height: 1; box-shadow: 0 4px 12px rgba(0,0,0,0.2);
   cursor: pointer; z-index: 1110;
+  transition: transform 200ms ease;
 }
 .fab:hover { background: var(--primary-hover); }
 .fab:focus { outline: 2px solid var(--primary-hover); outline-offset: 2px; }
+
+/* Rotate the FAB icon into an “X” when the composer is open */
+body.modal-open #fabAdd{
+  transform: rotate(45deg);
+}
+
+/* When both overflow and composer are open, retain translation */
+body.modal-open.overflow-open #fabAdd{
+  transform: translateY(8px) rotate(45deg);
+}
 
 /* Hide/disable the global floating FAB while overflow panel is open */
 body.overflow-open .fab{


### PR DESCRIPTION
## Summary
- Rotate FAB plus icon into an X when the composer is open
- Toggle the composer open/closed when clicking the FAB

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae111fd4fc8326a097d626502c5fb5