### PR TITLE
refactor: centralize section padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
 
         <!-- TAB: STORES -->
         <section id="tab-stores" class="tabpage">
-            <div class="section__body" style="padding: 16px;">
+            <div class="section__body">
                 <h2 style="margin: 0 0 8px;">🏬 Winkels</h2>
                 <p style="color: #64748b; margin: 0;">Hier beheer je winkelprofielen, stel je een actieve winkel in en pas je de categorievolgorde aan.</p>
             </div>
@@ -109,7 +109,7 @@
 
       <!-- TAB: ITEMS (catalog manager) -->
         <section id="tab-items" class="tabpage">
-          <div class="section__body" style="padding:16px;">
+          <div class="section__body">
             <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:10px;">
               <h2 style="margin:0;">🥕 Ingrediënten</h2>
               <button id="itemAddBtn" class="btn primary">Nieuw ingrediënt</button>

--- a/styles.css
+++ b/styles.css
@@ -14,6 +14,7 @@ html, body { overflow-x: hidden; }
   --border: #e2e8f0;
   --radius: 12px;
   --tabbar-h: 64px;
+  --section-pad: 16px;
 }
 
 body{
@@ -144,7 +145,7 @@ details.section > summary{
 details.section > summary::-webkit-details-marker{ display:none; }
 details.section[open] > summary{ background:#eaefff; }
 .section__chev { font-weight:700; width:1.1em; text-align:center; }
-.section__body { padding:14px; background:#fff; }
+.section__body { padding: var(--section-pad); background:#fff; }
 
 /* ========== Meals row (single-line horizontal scroll) ========== */
 .meal-row{


### PR DESCRIPTION
## Summary
- add `--section-pad` variable to `:root`
- use `--section-pad` for `.section__body` padding
- remove inline padding styles from `section__body` elements in `index.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1027092c8326a881c706d6218c85