### PR TITLE
feat: add recipes management entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,7 @@
             <div id="overflowPanel" class="overflow-panel" role="menu" aria-label="Meer acties">
               <ul class="overflow-list">
                 <li role="menuitem"><button id="miManageIngredients">🥕 Ingrediënten beheren</button></li>
+                <li role="menuitem"><button id="miManageRecipes">🍳 Recepten beheren</button></li>
                 <li role="menuitem"><button id="miStores">🏬 Winkels</button></li>
                 <!-- future options go here -->
                 <!-- <li role="menuitem"><button>⚙️ Instellingen</button></li> -->

--- a/main.js
+++ b/main.js
@@ -221,6 +221,13 @@ document.addEventListener('DOMContentLoaded', () => {
     mod.openItemsManagerDialog?.();
   });
 
+  /* Recipes management action */
+  document.getElementById('miManageRecipes')?.addEventListener('click', () => {
+    closeOverflow();
+    // navigate to the recipes management view
+    location.hash = '#/recipes';
+  });
+
   // Open Winkels from overflow (no tab button needed)
   document.getElementById('miStores')?.addEventListener('click', () => {
     closeOverflow();


### PR DESCRIPTION
## Summary
- Add a Manage Recipes option in the overflow menu
- Wire menu action to navigate to the recipe management view

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68af034b4b5c8326806ee08ea4f5a13a