### PR TITLE
Show readiness state on recipe cards

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -397,6 +397,22 @@ dialog{
   border:1px solid var(--border); border-radius:12px; background:#fff; padding:12px;
   display:grid; gap:8px;
 }
+.recipe-card.ready{
+  border-color:#86efac;
+  background:#f0fdf4;
+}
+.recipe-card.ready .badge.status{
+  background:#dcfce7;
+  color:#166534;
+}
+.recipe-card.out-of-scope{
+  border-color:var(--border);
+  background:#f8fafc;
+}
+.recipe-card.out-of-scope .badge.status{
+  background:#e2e8f0;
+  color:#475569;
+}
 .recipe-card header{ display:flex; justify-content:space-between; align-items:center; gap:8px; }
 .recipe-card .tags{ display:flex; flex-wrap:wrap; gap:6px; }
 .recipe-card .tags span{


### PR DESCRIPTION
## Summary
- Tag recipe cards as `ready` or `out-of-scope`
- Display status badge in card header
- Style ready/out-of-scope recipe cards and badges

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68af0d0ca58c832685b5efc8ad88289b