### PR TITLE
Fix syntax error in recipes feature

### DIFF
--- a/features/recipes.js
+++ b/features/recipes.js
@@ -84,9 +84,6 @@ function renderRecipesPage(){
     return;
   }
 
-  const ready = [];
-  const other = [];
-
   names.forEach(name => {
     const items = combinedMeals[name] || [];
     const isCustom = !!customRecipeDocs[name];
@@ -145,29 +142,9 @@ function renderCard(name, items, isCustom, isActive){
     ro.textContent = 'Standaard recept';
     actions.append(ro);
   }
-  
-    card.append(header, tags, actions);
 
-    (readyMeals.has(name) ? ready : other).push(card);
-  });
-
-  if(ready.length){
-    const h = document.createElement('h3');
-    h.textContent = 'Ready to cook';
-    h.style.gridColumn = '1 / -1';
-    h.style.margin = '0';
-    recipesListEl.appendChild(h);
-    ready.forEach(card => recipesListEl.appendChild(card));
-  }
-
-  if(other.length){
-    const h = document.createElement('h3');
-    h.textContent = 'Other recipes';
-    h.style.gridColumn = '1 / -1';
-    h.style.margin = '0';
-    recipesListEl.appendChild(h);
-    other.forEach(card => recipesListEl.appendChild(card));
-  }
+  card.append(header, actions);
+  return card;
 }
 
 /* ---------- Dialog ---------- */


### PR DESCRIPTION
## Summary
- remove leftover code from recipes rendering
- return recipe card element without undefined references

## Testing
- `node features/__tests__/recipes.parseItems.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68af13e9d76c8326b316946836e4d4b2