### PR TITLE
feat: show ready meals count in progress ring

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
             <svg id="progressRing" viewBox="0 0 36 36" hidden>
               <circle class="ring-bg" cx="18" cy="18" r="16"></circle>
               <circle class="ring-progress" cx="18" cy="18" r="16"></circle>
+              <text class="ring-count" x="18" y="21"></text>
               <text class="ring-check" x="18" y="21">✓</text>
             </svg>
             <!-- ⬇️ KEEP your existing List UI inside this section ⬇️ -->

--- a/styles.css
+++ b/styles.css
@@ -93,27 +93,33 @@ h1 {
   border-radius:50%;
   box-shadow:0 2px 6px rgba(0,0,0,0.15);
 }
-#progressRing circle{
-  fill:none;
-  stroke-width:4;
-  transform:rotate(-90deg);
-  transform-origin:50% 50%;
-}
-#progressRing .ring-bg{
-  stroke:var(--border);
-}
-#progressRing .ring-progress{
-  stroke:var(--primary);
-  stroke-linecap:round;
-  stroke-dasharray:100;
-  stroke-dashoffset:100;
-  transition:stroke-dashoffset .3s ease;
-}
-#progressRing .ring-check{
-  font-size:.9rem;
-  text-anchor:middle;
-  fill:var(--accent);
-  opacity:0;
+  #progressRing circle{
+    fill:none;
+    stroke-width:4;
+    transform:rotate(-90deg);
+    transform-origin:50% 50%;
+  }
+  #progressRing .ring-bg{
+    stroke:var(--border);
+  }
+  #progressRing .ring-progress{
+    stroke:var(--primary);
+    stroke-linecap:round;
+    stroke-dasharray:100;
+    stroke-dashoffset:100;
+    transition:stroke-dashoffset .3s ease;
+  }
+  #progressRing .ring-count{
+    font-size:.9rem;
+    text-anchor:middle;
+    fill:var(--accent);
+    display:none;
+  }
+  #progressRing .ring-check{
+    font-size:.9rem;
+    text-anchor:middle;
+    fill:var(--accent);
+    opacity:0;
   transition:opacity .3s ease;
 }
 #progressRing.completed .ring-progress{


### PR DESCRIPTION
## Summary
- display number of ready meals inside the progress ring on the list page
- calculate ready-meal count from checked ingredients and update dynamically
- keep existing purple checkmark when all items are completed

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check features/list.js`


------
https://chatgpt.com/codex/tasks/task_e_68afe8962f208326b5c23c6097acc575