### PR TITLE
Grey out completed items when shown

### DIFF
--- a/features/list.js
+++ b/features/list.js
@@ -317,6 +317,9 @@ function renderList(){
       const data = activeItems[name];
       const row = document.createElement("li");
       row.className = "item-row";
+      if (data.checked) {
+        row.classList.add("crossed");
+      }
 
       const qtyNum  = Number(data.count || 1);
       const unitStr = data.unit ? ` <span class="unit">(${data.unit})</span>` : "";

--- a/styles.css
+++ b/styles.css
@@ -279,7 +279,13 @@ details.section[open] > summary{ background:#eaefff; }
 .section__items > li.item-row:hover{ background: #f8fafc; }
 
 .shopping-list small{ color: var(--muted); font-size: .75rem; }
-.shopping-list li.crossed{ text-decoration: line-through; color: var(--muted); }
+.shopping-list li.crossed {
+  opacity: 0.6;
+}
+.shopping-list li.crossed .label {
+  text-decoration: line-through;
+  color: var(--muted);
+}
 
 /* ========== Custom input ========== */
 .custom-input{ display:flex; gap:8px; margin-top:20px; }


### PR DESCRIPTION
## Summary
- Grey out and strike through checked items when showing completed list entries
- Style ensures completed items appear muted and crossed off

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afea23b7408326a3e03c74ced1245a