### PR TITLE
Move item quantity controls to overflow menu

### DIFF
--- a/features/list.js
+++ b/features/list.js
@@ -337,19 +337,18 @@ function renderList(){
         row.classList.add("crossed");
       }
 
-      const qtyNum  = Number(data.count || 1);
-      const unitStr = data.unit ? ` <span class="unit">(${data.unit})</span>` : "";
+      const qtyNum = Number(data.count || 1);
+      const qtyStr = data.unit ? `${qtyNum}${data.unit}` : `${qtyNum}`;
 
       row.innerHTML = `
         <div class="item-row__main">
           <label class="checkbox">
             <input type="checkbox" ${data.checked ? "checked" : ""}/>
-            <span class="label">${name}${unitStr}</span>
+            <span class="qty">${qtyStr}</span>
+            <span class="label">${name}</span>
           </label>
         </div>
         <div class="item-row__actions">
-          <span class="qty">${qtyNum}</span>
-
           <div class="overflow">
             <button class="btn-overflow" aria-haspopup="menu" aria-expanded="false" aria-label="Meer acties">⋮</button>
             <div class="menu" role="menu" hidden>

--- a/features/list.js
+++ b/features/list.js
@@ -301,6 +301,8 @@ function renderList(){
     document.querySelectorAll(".item-row .menu").forEach(m => m.setAttribute("hidden",""));
     document.querySelectorAll(".item-row .btn-overflow[aria-expanded='true']")
       .forEach(b => b.setAttribute("aria-expanded","false"));
+    document.querySelectorAll(".item-row.menu-open")
+      .forEach(r => r.classList.remove("menu-open"));
   };
   document.addEventListener("click", window.__grocifyCloseMenus);
 
@@ -386,6 +388,7 @@ function renderList(){
         if (willOpen) {
           menu.removeAttribute("hidden");
           ovBtn.setAttribute("aria-expanded","true");
+          row.classList.add("menu-open");
         }
       });
 

--- a/features/list.js
+++ b/features/list.js
@@ -348,13 +348,13 @@ function renderList(){
           </label>
         </div>
         <div class="item-row__actions">
-          <button class="btn-qty minus" aria-label="Verlaag aantal">−</button>
           <span class="qty">${qtyNum}</span>
-          <button class="btn-qty plus" aria-label="Verhoog aantal">＋</button>
 
           <div class="overflow">
             <button class="btn-overflow" aria-haspopup="menu" aria-expanded="false" aria-label="Meer acties">⋮</button>
             <div class="menu" role="menu" hidden>
+              <button class="menu__item inc" role="menuitem">Aantal verhogen</button>
+              <button class="menu__item dec" role="menuitem">Aantal verlagen</button>
               <button class="menu__item delete" role="menuitem">Verwijderen</button>
             </div>
           </div>
@@ -377,12 +377,6 @@ function renderList(){
         await cloudToggleCheck(name, cb.checked);
       });
 
-      // Qty controls
-      row.querySelector(".btn-qty.plus")
-        .addEventListener("click", () => adjustQty(name, +1));
-      row.querySelector(".btn-qty.minus")
-        .addEventListener("click", () => adjustQty(name, -1));
-
       // Overflow menu
       const ovBtn = row.querySelector(".btn-overflow");
       const menu  = row.querySelector(".menu");
@@ -396,6 +390,17 @@ function renderList(){
           ovBtn.setAttribute("aria-expanded","true");
         }
       });
+
+      row.querySelector(".menu__item.inc")
+        .addEventListener("click", () => {
+          adjustQty(name, +1);
+          window.__grocifyCloseMenus();
+        });
+      row.querySelector(".menu__item.dec")
+        .addEventListener("click", () => {
+          adjustQty(name, -1);
+          window.__grocifyCloseMenus();
+        });
 
       row.querySelector(".menu__item.delete")
         .addEventListener("click", () => deleteItemWithUndo(name));

--- a/features/list.js
+++ b/features/list.js
@@ -344,8 +344,7 @@ function renderList(){
         <div class="item-row__main">
           <label class="checkbox">
             <input type="checkbox" ${data.checked ? "checked" : ""}/>
-            <span class="qty">${qtyStr}</span>
-            <span class="label">${name}</span>
+            <span class="label">${name}</span><span class="qty">${qtyStr}</span>
           </label>
         </div>
         <div class="item-row__actions">

--- a/styles.css
+++ b/styles.css
@@ -286,6 +286,10 @@ details.section[open] > summary{ background:#eaefff; }
   text-decoration: line-through;
   color: var(--muted);
 }
+.shopping-list li.crossed .qty {
+  text-decoration: line-through;
+  color: var(--muted);
+}
 
 /* ========== Custom input ========== */
 .custom-input{ display:flex; gap:8px; margin-top:20px; }
@@ -666,6 +670,7 @@ body.modal-open { overflow: hidden; }
   min-width: 20px;
   text-align: center;
   font-variant-numeric: tabular-nums;
+  margin-right: 6px;
 }
 
 /* ========== Clear-list inline button ========== */

--- a/styles.css
+++ b/styles.css
@@ -380,7 +380,7 @@ dialog{
 .tabbar .overflow.is-open .menu{ display:block; }
 
 /* Generic overflow menus (used elsewhere, not in tabbar) */
-.overflow { position: relative; z-index: 10; }
+.overflow { position: relative; }
 .overflow .menu {
   position: absolute;
   right: 0; top: 36px;
@@ -389,7 +389,7 @@ dialog{
   border-radius: 12px;
   box-shadow: 0 8px 24px rgba(0,0,0,0.12);
   min-width: 160px;
-  z-index: 200;
+  z-index: 1200;
 }
 .overflow .menu[hidden] { display: none; }
 .menu__item {

--- a/styles.css
+++ b/styles.css
@@ -670,7 +670,7 @@ body.modal-open { overflow: hidden; }
   min-width: 20px;
   text-align: center;
   font-variant-numeric: tabular-nums;
-  margin-right: 6px;
+  margin-left: 6px;
 }
 
 /* ========== Clear-list inline button ========== */

--- a/styles.css
+++ b/styles.css
@@ -648,6 +648,7 @@ body.modal-open { overflow: hidden; }
 /* ========== Item row controls ========== */
 .item-row {
   display: flex; align-items: center; justify-content: space-between; padding: 8px 4px;
+  position: relative;
 }
 .item-row__main { min-width: 0; }
 .item-row__actions { display: inline-flex; align-items: center; gap: 8px; }
@@ -665,6 +666,8 @@ body.modal-open { overflow: hidden; }
   font-size: 24px; line-height: 1;
   display:flex; align-items:center; justify-content:center;
 }
+
+.item-row.menu-open { z-index: 1250; }
 .btn-qty:hover, .btn-overflow:hover, .btn-icon:hover { background: #f8fafc; }
 .item-row .qty {
   min-width: 20px;

--- a/styles.css
+++ b/styles.css
@@ -279,9 +279,6 @@ details.section[open] > summary{ background:#eaefff; }
 .section__items > li.item-row:hover{ background: #f8fafc; }
 
 .shopping-list small{ color: var(--muted); font-size: .75rem; }
-.shopping-list li.crossed {
-  opacity: 0.6;
-}
 .shopping-list li.crossed .label {
   text-decoration: line-through;
   color: var(--muted);

--- a/styles.css
+++ b/styles.css
@@ -376,7 +376,7 @@ dialog{
 .tabbar .overflow.is-open .menu{ display:block; }
 
 /* Generic overflow menus (used elsewhere, not in tabbar) */
-.overflow { position: relative; }
+.overflow { position: relative; z-index: 10; }
 .overflow .menu {
   position: absolute;
   right: 0; top: 36px;
@@ -385,7 +385,7 @@ dialog{
   border-radius: 12px;
   box-shadow: 0 8px 24px rgba(0,0,0,0.12);
   min-width: 160px;
-  z-index: 20;
+  z-index: 200;
 }
 .overflow .menu[hidden] { display: none; }
 .menu__item {


### PR DESCRIPTION
## Summary
- Move per-item quantity adjust controls into each overflow menu and remove inline +/- buttons
- Raise overflow menu z-index so menus appear above list items

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68afedf89f74832682764c7300d2715b