### PR TITLE
Improve meal deselection and recipe removal

### DIFF
--- a/features/list.js
+++ b/features/list.js
@@ -199,8 +199,45 @@ function renderMeals(){
       btn.addEventListener("click", async () => {
         const turnOn = !btn.classList.contains("active");
         btn.classList.toggle("active", turnOn);
-        if (turnOn) { await cloudAddRecipe(name);  activeMeals.add(name); }
-        else        { await cloudRemoveRecipe(name); activeMeals.delete(name); }
+
+        if (turnOn) {
+          await cloudAddRecipe(name);
+          activeMeals.add(name);
+        } else {
+          // remove items locally for snappier UI
+          const prevItems = {};
+          Object.entries(activeItems).forEach(([k,v]) => {
+            prevItems[k] = { ...v, sources: new Set(v.sources) };
+          });
+          const items = combinedMeals[name] || [];
+          items.forEach(n => {
+            const data = activeItems[n];
+            if (!data) return;
+            data.sources?.delete(name);
+            data.count = Math.max(0, (data.count || 1) - 1);
+            if (data.count <= 0 || (data.sources && data.sources.size === 0)) {
+              delete activeItems[n];
+            }
+          });
+          renderList();
+          updateProgressRing();
+          setClearCtaVisible(Object.keys(activeItems).length > 0);
+
+          try {
+            await cloudRemoveRecipe(name);
+            activeMeals.delete(name);
+          } catch(e) {
+            console.error('cloudRemoveRecipe failed', e);
+            // revert local state and UI
+            activeItems = prevItems;
+            renderList();
+            updateProgressRing();
+            btn.classList.add('active');
+            alert('Kon maaltijd niet verwijderen');
+            return;
+          }
+        }
+
         await saveMealState();
         updateCounter(); // no-op if #mealCounter isn't present; safe
       });
@@ -841,12 +878,19 @@ async function cloudRemoveSource(name, source){
 }
 async function cloudRemoveRecipe(recipeName){
   const items = combinedMeals[recipeName] || [];
-  const batch = firebase.firestore().batch();
-  items.forEach(n => {
+  await Promise.all(items.map(async n => {
     const ref = itemsCol.doc(slug(n));
-    batch.set(ref, { origins: arrDel(recipeName) }, { merge: true });
-  });
-  await batch.commit();
+    const snap = await ref.get();
+    if (!snap.exists) return;
+    const data = snap.data() || {};
+    const nextCount = (data.count || 0) - 1;
+    const nextOrigins = (data.origins || []).filter(x => x !== recipeName);
+    if (nextCount <= 0 || nextOrigins.length === 0) {
+      await ref.delete();
+    } else {
+      await ref.set({ count: nextCount, origins: nextOrigins }, { merge: true });
+    }
+  }));
 }
 async function cloudAddRecipe(recipeName){
   const items = combinedMeals[recipeName] || [];

--- a/features/list.js
+++ b/features/list.js
@@ -10,6 +10,8 @@ let customRecipeDocs = {};              // name -> { id, items: string[] }
 let combinedMeals = {};                 // name -> items[] (strings)
 let KNOWN_ITEMS = [];
 let showCompleted = false;
+let suppressItemsSnapshot = false;      // ignore list snapshot when locally mutating
+let pendingItemsSnapshot = null;        // latest items snapshot while suppressed
 // Persisted preference key for showing completed items
 const SHOW_COMPLETED_KEY = "grocify_showCompleted_v1";
 
@@ -89,7 +91,14 @@ export function initListFeature(){
 
   // list items live
   itemsCol.onSnapshot(
-    snap => setActiveFromCloud(snap.docs.map(d => d.data())),
+    snap => {
+      const docs = snap.docs.map(d => d.data());
+      if (suppressItemsSnapshot) {
+        pendingItemsSnapshot = docs;
+      } else {
+        setActiveFromCloud(docs);
+      }
+    },
     err  => console.error("onSnapshot items error", err)
   );
 
@@ -204,6 +213,8 @@ function renderMeals(){
           await cloudAddRecipe(name);
           activeMeals.add(name);
         } else {
+          suppressItemsSnapshot = true;
+          pendingItemsSnapshot = null;
           // remove items locally for snappier UI
           const prevItems = {};
           Object.entries(activeItems).forEach(([k,v]) => {
@@ -235,6 +246,12 @@ function renderMeals(){
             btn.classList.add('active');
             alert('Kon maaltijd niet verwijderen');
             return;
+          } finally {
+            suppressItemsSnapshot = false;
+            if (pendingItemsSnapshot) {
+              setActiveFromCloud(pendingItemsSnapshot);
+              pendingItemsSnapshot = null;
+            }
           }
         }
 


### PR DESCRIPTION
## Summary
- Remove deselected meal items from local state and render before Firestore updates
- Parallelize recipe removal and decrement/remove items accordingly
- Surface errors and revert state when Firestore operations fail

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/grocify/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b9a41843e4832683e53a1bc42a994b