### PR TITLE
feat: add recipes overview tab

### DIFF
--- a/features/recipes.overview.js
+++ b/features/recipes.overview.js
@@ -1,0 +1,39 @@
+import { stateDoc } from '../firebase.js';
+
+let mealStatusEl;
+let activeMeals = new Set();
+let readyMeals = new Set();
+
+export function initRecipesOverview() {
+  mealStatusEl = document.getElementById('mealStatus');
+  if (!mealStatusEl) return;
+
+  stateDoc.onSnapshot(
+    (doc) => {
+      const data = doc.data() || {};
+      activeMeals = new Set(Array.isArray(data.activeMeals) ? data.activeMeals : []);
+      readyMeals = new Set(Array.isArray(data.readyMeals) ? data.readyMeals : []);
+      render();
+    },
+    (err) => console.error('stateDoc onSnapshot error', err)
+  );
+}
+
+export function refreshRecipesOverview() {
+  render();
+}
+
+function render() {
+  if (!mealStatusEl) return;
+  mealStatusEl.innerHTML = '';
+
+  const allMeals = Array.from(new Set([...activeMeals, ...readyMeals])).sort((a, b) => a.localeCompare(b));
+
+  allMeals.forEach((meal) => {
+    const pill = document.createElement('span');
+    pill.className = 'meal-pill';
+    if (!readyMeals.has(meal)) pill.classList.add('pending');
+    pill.textContent = meal;
+    mealStatusEl.appendChild(pill);
+  });
+}

--- a/index.html
+++ b/index.html
@@ -76,8 +76,13 @@
             <button id="clearListBtn" class="clear-list">🗑️ Lijst leegmaken</button>
         </section>
 
-        <!-- TAB: RECIPES (placeholder for M3) -->
+        <!-- TAB: RECIPES OVERVIEW -->
         <section id="tab-recipes" class="tabpage">
+            <div id="mealStatus"></div>
+        </section>
+
+        <!-- Recipe manager (legacy UI) -->
+        <section id="tab-recipes-manager" class="tabpage" hidden>
             <div class="recipes-toolbar">
                 <h2 style="margin: 0;">🍳 Recepten</h2>
                 <div class="recipes-toolbar-actions">

--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 import { initFirebase } from "./firebase.js";
 import { initListFeature, updateProgressRing } from "./features/list.js";
-import { initRecipesFeature } from "./features/recipes.js";
+import { initRecipesOverview } from "./features/recipes.overview.js";
 import { initStoresFeature } from "./features/stores.js";
 
 /* ===== Composer (bottom sheet) ===== */
@@ -230,7 +230,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Features
   initListFeature();
-  initRecipesFeature();
+  initRecipesOverview();
   initStoresFeature({
     onActiveStoreChanged(){
       if (typeof window.renderList === "function") window.renderList();

--- a/styles.css
+++ b/styles.css
@@ -160,6 +160,25 @@ h1 {
 }
 .section__badge { margin-left: auto; }
 
+/* Meals overview */
+#mealStatus {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 16px;
+}
+
+.meal-pill {
+  background: #e2e8f0;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-weight: 600;
+}
+
+.meal-pill.pending {
+  opacity: 0.5;
+}
+
 /* ========== Collapsible sections (Maaltijden / Weekboodschappen) ========== */
 details.section{
   border-radius:16px; border:1px solid var(--border); background:#fff;


### PR DESCRIPTION
## Summary
- add recipes overview section and hide legacy recipe manager
- render union of active and ready meals as pills
- hook overview into app boot and style pills

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b9a4c7aae08326b56e0c805a8094ae