### PR TITLE
Move recipes manager to overflow menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,8 +76,8 @@
             <button id="clearListBtn" class="clear-list">🗑️ Lijst leegmaken</button>
         </section>
 
-        <!-- TAB: RECIPES (placeholder for M3) -->
-        <section id="tab-recipes" class="tabpage">
+        <!-- RECIPES MANAGER -->
+        <section id="recipes-manager">
             <div class="recipes-toolbar">
                 <h2 style="margin: 0;">🍳 Recepten</h2>
                 <div class="recipes-toolbar-actions">
@@ -126,7 +126,6 @@
         <!-- Bottom tab bar -->
         <nav class="tabbar" role="tablist" aria-label="Navigatie">
           <button id="tabbtn-list" role="tab" aria-controls="tab-list"><span>📝</span>Lijst</button>
-          <button id="tabbtn-recipes" role="tab" aria-controls="tab-recipes"><span>🍳</span>Recepten</button>
 
           <!-- ⋮ overflow (bottom-sheet style) -->
           <div class="overflow">
@@ -136,6 +135,7 @@
             <div id="overflowPanel" class="overflow-panel" role="menu" aria-label="Meer acties">
               <ul class="overflow-list">
                 <li role="menuitem"><button id="miManageIngredients">🥕 Ingrediënten beheren</button></li>
+                <li role="menuitem"><button id="miRecipes">🍳 Recepten beheren</button></li>
                 <li role="menuitem"><button id="miStores">🏬 Winkels</button></li>
                 <!-- future options go here -->
                 <!-- <li role="menuitem"><button>⚙️ Instellingen</button></li> -->

--- a/main.js
+++ b/main.js
@@ -1,6 +1,5 @@
 import { initFirebase } from "./firebase.js";
 import { initListFeature, updateProgressRing } from "./features/list.js";
-import { initRecipesFeature } from "./features/recipes.js";
 import { initStoresFeature } from "./features/stores.js";
 
 /* ===== Composer (bottom sheet) ===== */
@@ -99,23 +98,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
   /* ===== Tabs Router ===== */
   function initRouter(){
-    const TABS = ["list","recipes","stores"];
+    const TABS = ["list","stores"];
     const DEFAULT_TAB = "list";
     const STORAGE_KEY = "ui-active-tab";
 
     const pages = {
-      list:    document.getElementById("tab-list"),
-      recipes: document.getElementById("tab-recipes"),
-      stores:  document.getElementById("tab-stores"),
+      list:   document.getElementById("tab-list"),
+      stores: document.getElementById("tab-stores"),
     };
     const buttons = {
-      list:    document.querySelectorAll('#tabbtn-list'),
-      recipes: document.querySelectorAll('#tabbtn-recipes'),
-      stores:  document.querySelectorAll('#tabbtn-stores'),
+      list:   document.querySelectorAll('#tabbtn-list'),
+      stores: document.querySelectorAll('#tabbtn-stores'),
     };
 
     function setActive(name){
       Object.entries(pages).forEach(([k,el]) => el?.classList.toggle("active", k===name));
+      document.getElementById('recipes-manager')?.classList.remove('open');
 
       // there are two sets of tab buttons (top + bottom), select all
       Object.entries(buttons).forEach(([k,nodeList]) => nodeList.forEach(btn => {
@@ -221,6 +219,20 @@ document.addEventListener('DOMContentLoaded', () => {
     mod.openItemsManagerDialog?.();
   });
 
+  /* Recipes manager action */
+  let recipesInit = false;
+  document.getElementById('miRecipes')?.addEventListener('click', async () => {
+    closeOverflow();
+    document.getElementById('tab-list')?.classList.remove('active');
+    document.getElementById('tab-stores')?.classList.remove('active');
+    document.getElementById('recipes-manager')?.classList.add('open');
+    if (!recipesInit) {
+      const mod = await import('./features/recipes.js');
+      mod.initRecipesFeature?.();
+      recipesInit = true;
+    }
+  });
+
   // Open Winkels from overflow (no tab button needed)
   document.getElementById('miStores')?.addEventListener('click', () => {
     closeOverflow();
@@ -230,7 +242,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Features
   initListFeature();
-  initRecipesFeature();
   initStoresFeature({
     onActiveStoreChanged(){
       if (typeof window.renderList === "function") window.renderList();

--- a/styles.css
+++ b/styles.css
@@ -354,6 +354,9 @@ dialog{
 .tabpage{ display:none; }
 .tabpage.active{ display:block; }
 
+#recipes-manager{ display:none; }
+#recipes-manager.open{ display:block; }
+
 /* Bottom tab bar */
 .tabbar{
   position: fixed; left: 0; right: 0; bottom: 0;
@@ -362,7 +365,7 @@ dialog{
   display:flex; align-items:center; gap:0; padding:0 8px;
   z-index:1000;
 }
-#tabbtn-list,#tabbtn-recipes,#tabbtn-stores{
+#tabbtn-list,#tabbtn-stores{
   flex:1 1 0; min-width:0;
   appearance:none; border:0; background:transparent;
   padding:10px 6px; font-size:.9rem; color:#475569;


### PR DESCRIPTION
## Summary
- Hide recipes tab and access it from a new "Recepten beheren" overflow action
- Lazy load recipes feature when managing recipes
- Style updates for new recipes manager section

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b9a4c63cc8832694cb71395068c01c