### PR TITLE
Add meal pill styles and readiness toggling

### DIFF
--- a/features/recipes.overview.js
+++ b/features/recipes.overview.js
@@ -1,0 +1,19 @@
+let readyMeals = new Set();
+
+export function initRecipesOverview(){
+  updatePills();
+  window.addEventListener('meals:ready', e => {
+    readyMeals = new Set(e.detail?.readyMeals || []);
+    updatePills();
+  });
+}
+
+function updatePills(){
+  document.querySelectorAll('.meal-pill').forEach(pill => {
+    const name = pill.dataset.meal || pill.textContent.trim();
+    const isReady = readyMeals.has(name);
+    pill.classList.toggle('ready', isReady);
+    pill.classList.toggle('pending', !isReady);
+  });
+}
+

--- a/styles.css
+++ b/styles.css
@@ -198,6 +198,34 @@ details.section[open] > summary{ background:#eaefff; }
   background:var(--accent);
   box-shadow:0 4px 14px rgba(124,58,237,.25);
 }
+
+/* Reusable meal pill buttons */
+.meal-pill{
+  background:var(--primary);
+  color:#fff;
+  border:none;
+  border-radius:16px;
+  padding:12px 16px;
+  font-weight:600;
+  box-shadow:0 2px 8px rgba(0,0,0,.08);
+  min-width:128px;
+  text-align:center;
+  transition:transform .06s ease, background .2s ease, box-shadow .2s ease;
+  scroll-snap-align:start;
+  flex:0 0 auto;
+}
+.meal-pill:hover{ background:var(--primary-hover); }
+.meal-pill:active{ transform:translateY(1px); }
+.meal-pill.active{
+  background:var(--accent);
+  box-shadow:0 4px 14px rgba(124,58,237,.25);
+}
+.meal-pill.pending{ opacity:.5; filter:grayscale(1); }
+.meal-pill.ready{ opacity:1; filter:none; }
+.meal-pill:focus-visible{
+  outline:2px solid var(--accent);
+  outline-offset:2px;
+}
 /* nicer horizontal scrollbar */
 .meal-row::-webkit-scrollbar{ height:6px; }
 .meal-row::-webkit-scrollbar-thumb{ background:#cbd5e1; border-radius:6px; }


### PR DESCRIPTION
## Summary
- add reusable `.meal-pill` styles with ready and pending states
- update recipes overview script to toggle pill readiness based on data

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b9a4c8eac48326b889b3553eefa92b