### PR TITLE
fix: align recipe manager id

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
         </section>
 
         <!-- Recipe manager (legacy UI) -->
-        <section id="tab-recipes-manager" class="tabpage" hidden>
+        <section id="recipes-manager" class="tabpage">
             <div class="recipes-toolbar">
                 <h2 style="margin: 0;">🍳 Recepten</h2>
                 <div class="recipes-toolbar-actions">


### PR DESCRIPTION
## Summary
- unify recipe manager IDs so JS & CSS target the same section
- remove hidden attribute to allow show/hide via `.open` class

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1c3d4fe4832694575f88d53bbd1b