### PR TITLE
feat: refresh recipes overview on meal events

### DIFF
--- a/features/recipes.overview.js
+++ b/features/recipes.overview.js
@@ -1,40 +1,22 @@
-import { stateDoc } from '../firebase.js';
-
 let mealStatusEl;
 let activeMeals = new Set();
 let readyMeals = new Set();
 
-// Below is legacy
-// export function initRecipesOverview() {
-//   mealStatusEl = document.getElementById('mealStatus');
-//   if (!mealStatusEl) return;
+export function initRecipesOverview() {
+  mealStatusEl = document.getElementById('mealStatus');
+  if (!mealStatusEl) return;
 
-//   stateDoc.onSnapshot(
-//     (doc) => {
-//       const data = doc.data() || {};
-//       activeMeals = new Set(Array.isArray(data.activeMeals) ? data.activeMeals : []);
-//       readyMeals = new Set(Array.isArray(data.readyMeals) ? data.readyMeals : []);
-//       render();
-//     },
-//     (err) => console.error('stateDoc onSnapshot error', err)
-//   );
-// }
+  window.addEventListener('meals:active-changed', (e) => {
+    activeMeals = new Set(e.detail?.activeMeals || []);
+    render();
+  });
 
-export function initRecipesOverview(){
-  updatePills();
-  window.addEventListener('meals:ready', e => {
+  window.addEventListener('meals:ready', (e) => {
     readyMeals = new Set(e.detail?.readyMeals || []);
-    updatePills();
+    render();
   });
-}
 
-function updatePills(){
-  document.querySelectorAll('.meal-pill').forEach(pill => {
-    const name = pill.dataset.meal || pill.textContent.trim();
-    const isReady = readyMeals.has(name);
-    pill.classList.toggle('ready', isReady);
-    pill.classList.toggle('pending', !isReady);
-  });
+  render();
 }
 
 export function refreshRecipesOverview() {


### PR DESCRIPTION
## Summary
- listen for `meals:active-changed` and `meals:ready` events in recipes overview
- refresh meal pills after event-driven state updates

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node features/__tests__/recipes.parseItems.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf2185ae8083269676029a83b3bbbe