### PR TITLE
Render meal status pills with ready or pending classes

### DIFF
--- a/features/recipes.overview.js
+++ b/features/recipes.overview.js
@@ -1,5 +1,3 @@
-import { stateDoc } from '../firebase.js';
-
 let mealStatusEl;
 let activeMeals = new Set();
 let readyMeals = new Set();
@@ -21,19 +19,19 @@ let readyMeals = new Set();
 // }
 
 export function initRecipesOverview(){
-  updatePills();
+  mealStatusEl = document.getElementById('mealStatus');
+  if (!mealStatusEl) return;
+
+  render();
+
+  window.addEventListener('meals:active-changed', e => {
+    activeMeals = new Set(e.detail?.activeMeals || []);
+    render();
+  });
+
   window.addEventListener('meals:ready', e => {
     readyMeals = new Set(e.detail?.readyMeals || []);
-    updatePills();
-  });
-}
-
-function updatePills(){
-  document.querySelectorAll('.meal-pill').forEach(pill => {
-    const name = pill.dataset.meal || pill.textContent.trim();
-    const isReady = readyMeals.has(name);
-    pill.classList.toggle('ready', isReady);
-    pill.classList.toggle('pending', !isReady);
+    render();
   });
 }
 
@@ -47,10 +45,11 @@ function render() {
 
   const allMeals = Array.from(new Set([...activeMeals, ...readyMeals])).sort((a, b) => a.localeCompare(b));
 
-  allMeals.forEach((meal) => {
+  allMeals.forEach(meal => {
     const pill = document.createElement('span');
     pill.className = 'meal-pill';
-    if (!readyMeals.has(meal)) pill.classList.add('pending');
+    pill.dataset.meal = meal;
+    pill.classList.add(readyMeals.has(meal) ? 'ready' : 'pending');
     pill.textContent = meal;
     mealStatusEl.appendChild(pill);
   });


### PR DESCRIPTION
## Summary
- Cache `mealStatusEl` in `initRecipesOverview`
- Render meal pills for union of active and ready meals with `ready`/`pending` classes

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68bf21832f988326b15f96e1692b0170