### PR TITLE
Refactor recipes overview to event-driven rendering

### DIFF
--- a/features/recipes.overview.js
+++ b/features/recipes.overview.js
@@ -1,40 +1,22 @@
-import { stateDoc } from '../firebase.js';
-
 let mealStatusEl;
 let activeMeals = new Set();
 let readyMeals = new Set();
 
-// Below is legacy
-// export function initRecipesOverview() {
-//   mealStatusEl = document.getElementById('mealStatus');
-//   if (!mealStatusEl) return;
-
-//   stateDoc.onSnapshot(
-//     (doc) => {
-//       const data = doc.data() || {};
-//       activeMeals = new Set(Array.isArray(data.activeMeals) ? data.activeMeals : []);
-//       readyMeals = new Set(Array.isArray(data.readyMeals) ? data.readyMeals : []);
-//       render();
-//     },
-//     (err) => console.error('stateDoc onSnapshot error', err)
-//   );
-// }
-
 export function initRecipesOverview(){
-  updatePills();
+  mealStatusEl = document.getElementById('mealStatus');
+  if (!mealStatusEl) return;
+
+  window.addEventListener('meals:active-changed', e => {
+    activeMeals = new Set(e.detail?.activeMeals || []);
+    render();
+  });
+
   window.addEventListener('meals:ready', e => {
     readyMeals = new Set(e.detail?.readyMeals || []);
-    updatePills();
+    render();
   });
-}
 
-function updatePills(){
-  document.querySelectorAll('.meal-pill').forEach(pill => {
-    const name = pill.dataset.meal || pill.textContent.trim();
-    const isReady = readyMeals.has(name);
-    pill.classList.toggle('ready', isReady);
-    pill.classList.toggle('pending', !isReady);
-  });
+  render();
 }
 
 export function refreshRecipesOverview() {
@@ -50,7 +32,11 @@ function render() {
   allMeals.forEach((meal) => {
     const pill = document.createElement('span');
     pill.className = 'meal-pill';
-    if (!readyMeals.has(meal)) pill.classList.add('pending');
+    if (readyMeals.has(meal)) {
+      pill.classList.add('ready');
+    } else {
+      pill.classList.add('pending');
+    }
     pill.textContent = meal;
     mealStatusEl.appendChild(pill);
   });


### PR DESCRIPTION
## Summary
- Remove `updatePills` logic in recipes overview
- Render meal pills on `meals:active-changed` and `meals:ready` events

## Testing
- `node --test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf217442b483269a7c16052ab983d7